### PR TITLE
fix(sketch): cannot open MCP interface

### DIFF
--- a/sketch-selection-helper.sketchplugin/Contents/Sketch/script.js
+++ b/sketch-selection-helper.sketchplugin/Contents/Sketch/script.js
@@ -90,7 +90,7 @@ function createPanel(options, context) {
   );
   
   // Set up communication between JavaScript and native code
-  var handler = WebViewMessageHandler.alloc().init();
+  var handler = new WebViewMessageHandler();
   handler.context = context;
   handler.panel = panel;
   contentController.addScriptMessageHandler_name(handler, "sketchPlugin");
@@ -541,4 +541,4 @@ var onCopySelectionIds = function(context) {
     log("Error in onCopySelectionIds: " + error);
     context.document.showMessage("Error: " + error);
   }
-}; 
+};


### PR DESCRIPTION
fix sketch plugin can not open MCP interface: 
Plugin error: TypeError: WebViewMessageHandler.alloc is not a function. (In ‘WebViewMessageHandler.alloc()’, ‘WebViewMessageHandler.alloc’ is undefined)

issue: #7 