### PR TITLE
Handle WebView messages without JSON parsing

### DIFF
--- a/sketch-selection-helper.sketchplugin/Contents/Sketch/script.js
+++ b/sketch-selection-helper.sketchplugin/Contents/Sketch/script.js
@@ -113,7 +113,15 @@ function createPanel(options, context) {
 function WebViewMessageHandler() {}
 WebViewMessageHandler.prototype.userContentController_didReceiveScriptMessage = function(controller, message) {
   try {
-    var data = JSON.parse(message.body());
+    var data = message.body();
+    if (typeof data === 'string') {
+      try {
+        data = JSON.parse(data);
+      } catch (parseError) {
+        log("Error parsing message JSON: " + parseError);
+        return;
+      }
+    }
     var type = data.type;
     
     switch (type) {


### PR DESCRIPTION
## Summary
- Avoid JSON parsing for WebView messages to prevent crashes when connecting or refreshing selection.

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c080abc0a08328b268dbe34b8441e3